### PR TITLE
fix: @Profile 로 인한 인수테스트 에러 수정

### DIFF
--- a/backend/src/main/java/com/umc/mwomeokji/DataLoader.java
+++ b/backend/src/main/java/com/umc/mwomeokji/DataLoader.java
@@ -16,7 +16,7 @@ import java.util.List;
 @Component
 @RequiredArgsConstructor
 @Transactional
-// @Profile("local")
+@Profile("local")
 public class DataLoader {
 
     private final DishRepository dishRepository;
@@ -59,10 +59,9 @@ public class DataLoader {
 
         // 임시 초기 질문리스트
         final List<Question> questionList = Arrays.asList(
-                Question.builder().question("시원한 음식은 어떠신가요?").build(),
-                Question.builder().question("면 종류를 드시겠습니까?").build(),
-                Question.builder().question("육류는 어떠신가요?").build(),
-                Question.builder().question("해산물은 좋아하시나요?").build()
+                Question.builder().question("혹시 멕시코, 동남아 요리 등 이색적인 메뉴는 어떠신가요?").build(),
+                Question.builder().question("혹시 매운 음식은 괜찮으신가요?").build(),
+                Question.builder().question("면 요리는 어떠신가요?").build()
         );
 
         questionRepository.saveAll(questionList);

--- a/backend/src/main/java/com/umc/mwomeokji/LocalDataController.java
+++ b/backend/src/main/java/com/umc/mwomeokji/LocalDataController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 import static org.springframework.http.HttpStatus.OK;
 
 @RestController
-// @Profile("local")
+@Profile("local")
 @RequiredArgsConstructor
 public class LocalDataController {
 

--- a/backend/src/main/java/com/umc/mwomeokji/LocalDataStarter.java
+++ b/backend/src/main/java/com/umc/mwomeokji/LocalDataStarter.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
-// @Profile("local")
+@Profile("local")
 @RequiredArgsConstructor
 public class LocalDataStarter implements ApplicationRunner {
 

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -1,0 +1,23 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;NON_KEYWORDS=USER
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+logging:
+  level:
+    org:
+      hibernate:
+        type:
+          descriptor:
+            sql: trace

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,23 +1,6 @@
 spring:
-  datasource:
-    url: jdbc:h2:mem:testdb;NON_KEYWORDS=USER
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
-  h2:
-    console:
-      enabled: true
-  jpa:
-    hibernate:
-      ddl-auto: create-drop
-    properties:
-      hibernate:
-        show_sql: true
-        format_sql: true
-logging:
-  level:
-    org:
-      hibernate:
-        type:
-          descriptor:
-            sql: trace
+  profiles:
+    group:
+      "prod": ""
+      "local": "local"
+    active: local

--- a/backend/src/test/java/com/umc/mwomeokji/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/umc/mwomeokji/acceptance/AcceptanceTest.java
@@ -6,8 +6,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
 public class AcceptanceTest {
 
     @LocalServerPort

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -1,0 +1,23 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;NON_KEYWORDS=USER
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+logging:
+  level:
+    org:
+      hibernate:
+        type:
+          descriptor:
+            sql: trace


### PR DESCRIPTION
## 작업내용
- @Profile 어노테이션으로 인한 인수테스트 에러 수정
<br>

## 주요 변경점
- 로컬 환경 설정을 위해 main.java 에 application-local.yml 파일을 추가, application.yml 에서 activate 하여 활성화 하도록 수정
- DataLoader.java, LocalDataController.java, LocalDataStarter.java 세 클래스의 경우 @Profile("local") 환경에서만 동작하도록 수정
- RANDOM_PORT @SpringBootTest 를 이용한 인수테스트에서 프로파일을 분리하지 않아 main.java 의 DataLoader.java 데이터가 데이터베이스에 저장되어 임의로 데이터를 삽입하여 테스트하는 인수테스트가 실패하는 케이스 발생
- test.java 에 application-test.yml 파일을 생성하여 데이터베이스 설정을 따로 지정
- 인수테스트에 @ActiveProfiles("test") 어노테이션을 두어 main.java 의 프로파일이 아니라 test.java 의 프로파일을 이용하도록 수정
<br>

## 유의할 점 (optional)
- x
<br>

## To Reviewers (optional)
- x
