### PR TITLE
feat: AWS S3 와 CloudFront 연동 및 이미지 확장자 validation 처리

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -21,6 +21,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.apache.tika:tika-core:2.4.1'
 
 	// OpenAPI 3.0
 	implementation 'org.springdoc:springdoc-openapi-ui:1.6.9'

--- a/backend/src/main/java/com/umc/mwomeokji/domain/dish/application/DishServiceImpl.java
+++ b/backend/src/main/java/com/umc/mwomeokji/domain/dish/application/DishServiceImpl.java
@@ -25,7 +25,8 @@ public class DishServiceImpl implements DishService{
 
     @Override
     public DishDetailsResponse saveDish(DishPostRequest request, MultipartFile multipartFile) {
-        Dish dish = save(request, multipartFile);
+        String imageUrl = fileService.uploadImage(multipartFile);
+        Dish dish = dishRepository.save(dishMapper.toEntity(request, imageUrl));
         return dishMapper.toDishDetailsResponse(dish);
     }
 
@@ -48,10 +49,5 @@ public class DishServiceImpl implements DishService{
         long qty = dishRepository.count();
         long idx = (long)(Math.random() * qty)+ 1;
         return dishMapper.toDishDetailsResponse(dishRepository.findById(idx).orElseThrow(NotFoundDishException::new));
-    }
-
-    private Dish save(DishPostRequest request, MultipartFile multipartFile) {
-        if (multipartFile == null) return dishRepository.save(dishMapper.toEntity(request));
-        else return dishRepository.save(dishMapper.toEntity(request, fileService.uploadImage(multipartFile)));
     }
 }

--- a/backend/src/main/java/com/umc/mwomeokji/domain/dish/dto/DishMapper.java
+++ b/backend/src/main/java/com/umc/mwomeokji/domain/dish/dto/DishMapper.java
@@ -9,8 +9,6 @@ public interface DishMapper {
 
     Dish toEntity(DishPostRequest dishPostRequest, String imageUrl);
 
-    Dish toEntity(DishPostRequest dishPostRequest);
-
     DishNameResponse toDishNameResponse(Dish dish);
 
     DishDetailsResponse toDishDetailsResponse(Dish dish);

--- a/backend/src/main/java/com/umc/mwomeokji/global/error/exception/ExceptionCodeAndDetails.java
+++ b/backend/src/main/java/com/umc/mwomeokji/global/error/exception/ExceptionCodeAndDetails.java
@@ -11,23 +11,32 @@ public enum ExceptionCodeAndDetails {
     METHOD_NOT_ALLOWED(405, "0003", "허용되지 않은 메소드 접근입니다. 올바른 HTTP Methods 를 입력해주세요."),
     INVALID_JSON_FORMAT(400, "0004", "유효하지 않은 json 형식입니다. 입력을 확인해주세요."),
     FILE_IO_EXCEPTION(500, "0005", "파일 입출력 과정에서 에러가 발생했습니다."),
-    AMAZON_SERVICE_EXCEPTION(500, "0006", "요청은 정상적으로 전달되었으나, AWS 내부 문제로 작업이 처리되지 않았습니다."),
-    SDK_CLIENT_EXCEPTION(500, "0007", "자바 코드 내부의 문제로 인해 에러가 발생했습니다."),
+    FILE_EXTENSION_EXCEPTION(400, "0006", "올바르지 않은 파일 확장자입니다."),
 
     // 1000: dish
     NOT_FOUND_DISH(404, "1001", "해당하는 id 의 메뉴를 찾을 수 없습니다."),
 
     // 2000: question
-    NOT_FOUND_QUESTION(404, "2001", "해당하는 id 의 질문을 찾을 수 없습니다.")
+    NOT_FOUND_QUESTION(404, "2001", "해당하는 id 의 질문을 찾을 수 없습니다."),
+
+
+    // 9000: AWS
+    AMAZON_SERVICE_EXCEPTION(500, "9001", "요청은 정상적으로 전달되었으나, AWS 내부 문제로 작업이 처리되지 않았습니다."),
+    SDK_CLIENT_EXCEPTION(500, "9002", "자바 코드 내부의 문제로 인해 에러가 발생했습니다.")
 
     ;
     private final int status;
     private final String code;
-    private final String message;
+    private String message;
 
     ExceptionCodeAndDetails(int status, String code, String message) {
         this.status = status;
         this.code = code;
         this.message = message;
+    }
+
+    ExceptionCodeAndDetails(int status, String code) {
+        this.status = status;
+        this.code = code;
     }
 }

--- a/backend/src/main/java/com/umc/mwomeokji/global/error/exception/ExceptionCodeAndDetails.java
+++ b/backend/src/main/java/com/umc/mwomeokji/global/error/exception/ExceptionCodeAndDetails.java
@@ -27,16 +27,11 @@ public enum ExceptionCodeAndDetails {
     ;
     private final int status;
     private final String code;
-    private String message;
+    private final String message;
 
     ExceptionCodeAndDetails(int status, String code, String message) {
         this.status = status;
         this.code = code;
         this.message = message;
-    }
-
-    ExceptionCodeAndDetails(int status, String code) {
-        this.status = status;
-        this.code = code;
     }
 }

--- a/backend/src/main/java/com/umc/mwomeokji/infra/s3/exception/AmazonException.java
+++ b/backend/src/main/java/com/umc/mwomeokji/infra/s3/exception/AmazonException.java
@@ -1,0 +1,11 @@
+package com.umc.mwomeokji.infra.s3.exception;
+
+import com.umc.mwomeokji.global.error.exception.BusinessException;
+import com.umc.mwomeokji.global.error.exception.ExceptionCodeAndDetails;
+
+public class AmazonException extends BusinessException {
+
+    public AmazonException(ExceptionCodeAndDetails codeAndDetails) {
+        super(codeAndDetails);
+    }
+}

--- a/backend/src/main/java/com/umc/mwomeokji/infra/s3/exception/FileException.java
+++ b/backend/src/main/java/com/umc/mwomeokji/infra/s3/exception/FileException.java
@@ -1,0 +1,11 @@
+package com.umc.mwomeokji.infra.s3.exception;
+
+import com.umc.mwomeokji.global.error.exception.BusinessException;
+import com.umc.mwomeokji.global.error.exception.ExceptionCodeAndDetails;
+
+public class FileException extends BusinessException {
+
+    public FileException(ExceptionCodeAndDetails codeAndDetails) {
+        super(codeAndDetails);
+    }
+}


### PR DESCRIPTION
## 작업내용
- AWS S3 와 CloudFront 연동
- 입력으로 들어온 이미지 확장자 validation 처리
- resolved: #51
<br>

## 주요 변경점
- client 로 imageUrl 을 넘겨주는 방식 변경
  - <b>기존 방식</b>: 이미지를 s3 에 저장한 후, s3 링크를 바로 client 로 넘겨주었었음
  - <b>변경된 방식</b>: s3 에 대한 public access 를 모두 막고, AWS CloudFront 를 통해서만 자원에 접근 가능하도록 변경, 따라서 자원에 대한 접근 권한이 있는 CloudFront 링크를 client 로 반환
- client 로부터 이미지를 받을 때와, 받지 않을 때에 대한 처리 방식 변경
  - <b>기존 방식</b>: 이미지를 받을 때와 받지 않을 때에 대한 method 를 나누어, 받는 경우에만 S3 이미지 저장 및 DB 에 자원 접근 링크를 저장하고, 받지 않는 경우에는 null 을 저장하였었음.
  - <b>변경된 방식</b>: method 를 하나로 통합하고, 이미지가 없는 경우에는 S3 에 저장되어 있는 default 이미지 url 을 갖도록 하여 없는 이미지에 대해서 기본 이미지를 제공할 수 있도록 변경
- 입력으로 들어온 이미지 확장자가 image 로 시작하는 MIME type 이 아닌 경우, 예외를 발생하도록 하여 예기치 못한 동작을 예방
- <a href=https://developer.mozilla.org/ko/docs/Web/HTTP/Basics_of_HTTP/MIME_types>MIME 타입</a>, <a href=https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types>Common MIME types</a> - MIME type 에 대해서는 해당 링크를 참조
<br>

## 유의할 점 (optional)
- x
<br>

## To Reviewers (optional)
- 이번에 변경점이 생각보다 많아서 혹시 이해 안되는 부분 있으면 꼭 남겨주기!!
<br>
