### PR TITLE
fix: Jar task 를 통해 생성되는 plain archive 비활성화

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -62,3 +62,8 @@ task copySubmodule(type: Copy){
 	include '*.yml'
 	into './src/main/resources'
 }
+
+// disable plain.jar
+jar {
+	enabled = false
+}


### PR DESCRIPTION
## 작업내용
- Jar task 를 통해 생성되는 plain archive 비활성화
<br>

## 주요 변경점
- gradle build 시 jar 파일이 2개 생성되는 문제 발생
- <a href=https://earth-95.tistory.com/132>빌드시 두 가지 jar 가 생성되는 현상</a>, <a href=https://docs.spring.io/spring-boot/docs/current/gradle-plugin/reference/htmlsingle/#packaging-executable.and-plain-archives>Packaging Executable and Plain Archives</a> - 참고하여 build.gradle 수정
<br>

## 유의할 점 (optional)
- x
<br>

## To Reviewers (optional)
- x
<br>
